### PR TITLE
ci: build slides PDF

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -1,0 +1,17 @@
+name: Build PDF
+on:
+  pull_request:
+
+jobs:
+  marp:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npx --yes @marp-team/marp-cli@latest slides.md --pdf --allow-local-files
+      - uses: actions/upload-artifact@v4
+        with:
+          name: slides
+          path: slides.pdf


### PR DESCRIPTION
## Summary
- build Marp markdown into PDF via GitHub Actions

## Testing
- `npx @marp-team/marp-cli@latest slides.md --pdf --allow-local-files` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@marp-team%2fmarp-cli)*

------
https://chatgpt.com/codex/tasks/task_e_68a6583551d88321aa333920c55fbed6