### PR TITLE
Fix PDF slides garbling by adding Japanese fonts

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -10,6 +10,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
+      - run: sudo apt-get update && sudo apt-get install -y fonts-noto-cjk
       - run: npx --yes @marp-team/marp-cli@latest slides.md --pdf --allow-local-files
       - uses: actions/upload-artifact@v4
         with:

--- a/slides.md
+++ b/slides.md
@@ -6,6 +6,11 @@ paginate: true
 math: mathjax
 header: 'Kinoko 2025'
 footer: 'Slide $page$ / $pages$'
+style: |
+  @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&display=swap');
+  section {
+    font-family: 'Noto Sans JP', sans-serif;
+  }
 ---
 
 # こんにちは


### PR DESCRIPTION
## Summary
- import Noto Sans JP in slides
- install Japanese font package before building PDF

## Testing
- `npx --yes @marp-team/marp-cli@latest slides.md --pdf --allow-local-files` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@marp-team%2fmarp-cli)*

------
https://chatgpt.com/codex/tasks/task_e_68a6982ea97c8321a4ae5c10cd53d2cb