### PR TITLE
Skip numbering on first slide

### DIFF
--- a/slides.md
+++ b/slides.md
@@ -12,7 +12,7 @@ style: |
     font-family: 'Noto Sans JP', sans-serif;
   }
 ---
-
+<!-- _paginate: skip -->
 # こんにちは
 
 これはシンプルなMarpスライドです。


### PR DESCRIPTION
## Summary
- Skip pagination for title slide so numbering begins on slide two

## Testing
- `npm install -g @marp-team/marp-cli` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@marp-team%2fmarp-cli)*
- `marp slides.md -o slides.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f5f8061c8321966f5ac3e2c1054a