### PR TITLE
Remove slide header/footer text and center divider heading

### DIFF
--- a/masters.css
+++ b/masters.css
@@ -39,6 +39,17 @@ section.divider {
   align-items: center;
   text-align: center;
   font-size: 2.5rem;
+  padding-top: 0;
+}
+
+section.divider h1:first-of-type,
+section.divider h2:first-of-type,
+section.divider h3:first-of-type {
+  position: static;
+  top: auto;
+  left: auto;
+  right: auto;
+  margin: 0;
 }
 
 /* Split slide: two column layout */

--- a/slides.md
+++ b/slides.md
@@ -4,8 +4,6 @@ theme: default
 title: きのこ観察の視点から見た再度公園の環境
 paginate: true
 math: mathjax
-header: 'Kinoko 2025'
-footer: 'Slide $page$ / $pages$'
 style: |
   @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&display=swap');
   @import './masters.css';


### PR DESCRIPTION
## Summary
- remove the custom header and footer so the slides no longer render the "Kinoko 2025" header nor the "Slide page/pages" footer
- adjust the divider slide layout to center its heading vertically without the fixed heading offset

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68e66ac574c883218a16434463d7ddd4