### PR TITLE
Align source notes at the bottom of slides

### DIFF
--- a/masters.css
+++ b/masters.css
@@ -14,6 +14,7 @@ section.cover {
 section:not(.cover) {
   position: relative;
   padding-top: 4rem;
+  padding-bottom: 4rem;
 }
 
 section:not(.cover) h1:first-of-type,

--- a/slides.md
+++ b/slides.md
@@ -11,10 +11,15 @@ style: |
     font-family: 'Noto Sans JP', sans-serif;
   }
   .source-note {
-    margin-top: 1.5rem;
-    font-size: 0.8rem;
+    position: absolute;
+    bottom: 1.5rem;
+    left: 2rem;
+    right: 2rem;
+    font-size: 0.7rem;
     color: #555;
     line-height: 1.4;
+    border-top: 1px solid rgba(0, 0, 0, 0.15);
+    padding-top: 0.5rem;
   }
   .source-note p {
     margin: 0.2rem 0 0;


### PR DESCRIPTION
## Summary
- anchor slide source notes at the bottom with a divider line and smaller text
- add extra bottom padding to non-cover slides so citations have breathing room

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6e7ae74ec8321a345e0a575da1e64