### PR TITLE
Improve visibility of slide headings

### DIFF
--- a/masters.css
+++ b/masters.css
@@ -25,6 +25,15 @@ section:not(.cover) h3:first-of-type {
   left: 2rem;
   right: 2rem;
   margin: 0;
+  padding: 0.5rem 1.25rem;
+  background: rgba(255, 255, 255, 0.92);
+  color: #2d2a26;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  border-left: 0.35rem solid #8c4a2f;
+  border-radius: 999px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  z-index: 1;
 }
 
 /* Content slide: default layout with padding */


### PR DESCRIPTION
## Summary
- add prominent styling to non-cover slide headings to clearly distinguish them from body text

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6eab2aff483219b0af15673ed1bd5