### PR TITLE
Fix footer positioning on slides

### DIFF
--- a/masters.css
+++ b/masters.css
@@ -40,6 +40,10 @@ section:not(.cover) h3:first-of-type {
 section.content {
   padding: 2rem;
   padding-top: 6rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  min-height: 100%;
 }
 
 /* Divider slide: big centered text */
@@ -75,6 +79,15 @@ section.split .column {
 /* Media slide: center media content */
 section.media {
   display: flex;
-  justify-content: center;
+  flex-direction: column;
   align-items: center;
+  gap: 1.5rem;
+  min-height: 100%;
+  padding: 2rem;
+  padding-top: 6rem;
+}
+
+section.media > :not(.source-note) {
+  margin-top: auto;
+  margin-bottom: auto;
 }

--- a/slides.md
+++ b/slides.md
@@ -11,15 +11,13 @@ style: |
     font-family: 'Noto Sans JP', sans-serif;
   }
   .source-note {
-    position: absolute;
-    bottom: 1.5rem;
-    left: 2rem;
-    right: 2rem;
+    margin-top: auto;
+    padding-top: 0.75rem;
+    border-top: 1px solid rgba(0, 0, 0, 0.15);
     font-size: 0.7rem;
     color: #555;
     line-height: 1.4;
-    border-top: 1px solid rgba(0, 0, 0, 0.15);
-    padding-top: 0.5rem;
+    width: 100%;
   }
   .source-note p {
     margin: 0.2rem 0 0;


### PR DESCRIPTION
## Summary
- stop treating slide source notes as absolutely positioned overlays so they no longer clash with content
- make content and media slide layouts flex-based so source notes reserve space at the bottom of the slide

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e72ebe21d08321b23dde5f908432c0