### PR TITLE
Adjust media slide layout for images

### DIFF
--- a/masters.css
+++ b/masters.css
@@ -81,13 +81,34 @@ section.media {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 1.5rem;
+  justify-content: center;
+  gap: 2rem;
   min-height: 100%;
-  padding: 2rem;
-  padding-top: 6rem;
+  padding: 2.5rem;
+  padding-top: 5rem;
 }
 
 section.media > :not(.source-note) {
-  margin-top: auto;
-  margin-bottom: auto;
+  margin: 0;
+  width: min(100%, 60rem);
+}
+
+section.media img,
+section.media svg {
+  display: block;
+  width: 100% !important;
+  height: auto;
+  max-height: min(70vh, calc(100vh - 12rem));
+  object-fit: contain;
+  margin: 0 auto;
+  border-radius: 0.75rem;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.18);
+  background: rgba(255, 255, 255, 0.85);
+  padding: 0.75rem;
+}
+
+section.media .source-note {
+  align-self: stretch;
+  width: min(100%, 60rem);
+  margin: 0 auto;
 }


### PR DESCRIPTION
## Summary
- refine the media slide layout to center imagery with balanced padding
- constrain image dimensions for consistent whitespace and readability
- align source notes to match the media width for a tidy presentation

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e7311c7ee083218cf8629652990653