### PR TITLE
Fix content slide vertical alignment

### DIFF
--- a/masters.css
+++ b/masters.css
@@ -42,6 +42,7 @@ section.content {
   padding-top: 6rem;
   display: flex;
   flex-direction: column;
+  justify-content: flex-start;
   gap: 1.5rem;
   min-height: 100%;
 }


### PR DESCRIPTION
## Summary
- ensure content slides justify their flex layout from the top so lists don't center when no source note is present

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68e777ee724c8321aecdc27d060c8046