### PR TITLE
Add max-height styling for slide images

### DIFF
--- a/slides.md
+++ b/slides.md
@@ -10,6 +10,16 @@ style: |
   section {
     font-family: 'Noto Sans JP', sans-serif;
   }
+  section img {
+    display: block;
+    max-width: 100%;
+    width: auto;
+    height: auto;
+    max-height: calc(100vh - 8rem);
+    object-fit: contain;
+    margin-left: auto;
+    margin-right: auto;
+  }
   .source-note {
     margin-top: auto;
     padding-top: 0.75rem;


### PR DESCRIPTION
## Summary
- constrain slide images with a max-height so they scale consistently within the viewport

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e77ef980b48321b0395b5ea4911958