### PR TITLE
Create side-by-side layout for natural environment slide

### DIFF
--- a/masters.css
+++ b/masters.css
@@ -92,3 +92,47 @@ section.media > :not(.source-note) {
   margin-top: auto;
   margin-bottom: auto;
 }
+
+/* Side-by-side layout for text and media */
+.side-by-side {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  gap: 2rem;
+}
+
+.side-by-side .side-text {
+  flex: 2;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.side-by-side .side-media {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  justify-content: center;
+}
+
+.side-by-side .side-media img {
+  width: 100%;
+  height: auto;
+  max-height: 70vh;
+  object-fit: contain;
+}
+
+.source-note {
+  width: 100%;
+  margin-top: 1.5rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid rgba(0, 0, 0, 0.15);
+  font-size: 0.7rem;
+  color: #555;
+  line-height: 1.4;
+}
+
+.source-note p {
+  margin: 0.2rem 0 0;
+}

--- a/slides.md
+++ b/slides.md
@@ -10,18 +10,6 @@ style: |
   section {
     font-family: 'Noto Sans JP', sans-serif;
   }
-  .source-note {
-    margin-top: auto;
-    padding-top: 0.75rem;
-    border-top: 1px solid rgba(0, 0, 0, 0.15);
-    font-size: 0.7rem;
-    color: #555;
-    line-height: 1.4;
-    width: 100%;
-  }
-  .source-note p {
-    margin: 0.2rem 0 0;
-  }
 ---
 <!-- _class: cover -->
 <!-- _paginate: skip -->
@@ -45,11 +33,19 @@ style: |
 <!-- _class: content -->
 
 ## 再度公園の自然環境
-- 再度公園周辺ではアカマツ林が広く分布し、林内にはソヨゴやヒサカキ、スダジイの低木もみられる。気候的極相としては、スダジイやアカガシを主体とする照葉樹林が発達する地域である。
-- 花崗岩が風化してできた砂質の土壌が広がり、水はけがよい反面、水もちが悪く乾燥しやすい環境を形成。アカマツ林ではpHがより酸性で、スダジイ林よりも土壌が未熟。
-- アカマツ林の中には将来スダジイ林へ移行する兆候がみられ、極相の照葉樹林へと遷移が進むと考えられる。植生とともに、土壌環境も長い時間をかけて変化していく。
 
-![width:70%](images/010_林層構造.jpg)
+<div class="side-by-side">
+  <div class="side-text">
+    <ul>
+      <li>再度公園周辺ではアカマツ林が広く分布し、林内にはソヨゴやヒサカキ、スダジイの低木もみられる。気候的極相としては、スダジイやアカガシを主体とする照葉樹林が発達する地域である。</li>
+      <li>花崗岩が風化してできた砂質の土壌が広がり、水はけがよい反面、水もちが悪く乾燥しやすい環境を形成。アカマツ林ではpHがより酸性で、スダジイ林よりも土壌が未熟。</li>
+      <li>アカマツ林の中には将来スダジイ林へ移行する兆候がみられ、極相の照葉樹林へと遷移が進むと考えられる。植生とともに、土壌環境も長い時間をかけて変化していく。</li>
+    </ul>
+  </div>
+  <div class="side-media">
+    <img src="images/010_林層構造.jpg" alt="再度公園の林層構造" />
+  </div>
+</div>
 
 <div class="source-note">
   <p>出典: 小舘 誓治（年不明）『自然とむきあう — 六甲山系における森林の植生と土壌を調べる』 https://www.hitohaku.jp/publication/30thanniv_10_rokkomt.pdf</p>


### PR DESCRIPTION
## Summary
- add a reusable flex-based `.side-by-side` layout in `masters.css` with controlled gaps and image sizing
- update the natural environment slide to use the new layout and keep its footer source note outside the flex container
- move the shared `.source-note` styling into the shared stylesheet so it can apply consistently across slides

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e871141ed08321b92966ba6b67fd58