### PR TITLE
Allow media slides to honor custom image sizing

### DIFF
--- a/masters.css
+++ b/masters.css
@@ -103,6 +103,12 @@ section.media img {
   object-fit: contain;            /* 切らずに収める */
 }
 
+/* マークダウン側で width / height を指定した場合はその値を優先させる */
+section.media img[style*="width"],
+section.media img[style*="height"] {
+  max-height: none;
+}
+
 /* 出典（あるときだけ下端に固定） */
 section.media:has(> footer.source-note) {
   --footer-h: 3.5rem;             /* フッターの見出し高を調整 */


### PR DESCRIPTION
## Summary
- let Markdown-defined width/height styles on media slide images override the template's viewport max-height rule
- ensure slides can display media images at differing scales when custom sizing is specified

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eb358316ec8321aec4f8a4c53a412e