### PR TITLE
Add configurable scale for media images

### DIFF
--- a/masters.css
+++ b/masters.css
@@ -82,6 +82,7 @@ section.split .column {
 section.media {
   /* footer 有無に応じて埋める高さ（初期は 0） */
   --footer-h: 0rem;
+  --media-img-scale: 1;           /* 画像の拡大率（デフォルトは等倍） */
   position: relative;
   padding: 0 0 var(--footer-h) 0; /* footer 分だけ下に余白 */
   min-height: 100vh;              /* スライド高いっぱい */
@@ -97,14 +98,18 @@ section.media > p {
 /* 画像は“収める”が基本。手動 width/height を邪魔しない */
 section.media img {
   display: inline-block;
-  max-width: 100%;
+  width: auto;
+  max-width: calc(100% * var(--media-img-scale));
   max-height: calc(100vh - var(--footer-h));
   height: auto;
   object-fit: contain;            /* 切らずに収める */
 }
 
 /* マークダウン側で width / height を指定した場合はその値を優先させる */
-section.media img[style*="width"],
+section.media img[style*="width"] {
+  max-width: none;
+}
+
 section.media img[style*="height"] {
   max-height: none;
 }

--- a/slides.html
+++ b/slides.html
@@ -267,7 +267,7 @@ section.nature-slide {
   height: auto;
 }
 " lang="en-US" class="media" data-marpit-pagination="4" style="--paginate:true;--class:media;--theme:default;--style:@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&amp;display=swap')
-;" data-marpit-pagination-total="22">
+;--media-img-scale:0.85;" data-marpit-pagination-total="22">
 <p><img src="images/020_%E4%BD%8D%E7%BD%AE%E5%9B%B31.jpg" alt="" /></p>
 <div class="source-note">
   <p>出典: 神戸まちガイド（2023）『再度公園 ― 神戸 まちガイド』 https://kobe-machiguide.com/park/futatabi-park/</p>
@@ -318,7 +318,7 @@ section.nature-slide {
   height: auto;
 }
 " lang="en-US" class="media" data-marpit-pagination="5" style="--paginate:true;--class:media;--theme:default;--style:@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&amp;display=swap')
-;" data-marpit-pagination-total="22">
+;--media-img-scale:0.85;" data-marpit-pagination-total="22">
 <p><img src="images/030_%E4%BD%8D%E7%BD%AE%E5%9B%B32.jpg" alt="" /></p>
 <div class="source-note">
   <p>出典: ルートふたたび（2023）『再度公園について – Futatabi Park』 https://routefutatabi.com/futatabi-park/</p>
@@ -369,7 +369,7 @@ section.nature-slide {
   height: auto;
 }
 " lang="en-US" class="media" data-marpit-pagination="6" style="--paginate:true;--class:media;--theme:default;--style:@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&amp;display=swap')
-;" data-marpit-pagination-total="22">
+;--media-img-scale:0.85;" data-marpit-pagination-total="22">
 <p><img src="images/040_default_01.jpg" alt="" /></p>
 </section>
 </foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="8" data-paginate="true" data-class="media" data-theme="default" data-style="@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&amp;display=swap');
@@ -417,7 +417,7 @@ section.nature-slide {
   height: auto;
 }
 " lang="en-US" class="media" data-marpit-pagination="7" style="--paginate:true;--class:media;--theme:default;--style:@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&amp;display=swap')
-;" data-marpit-pagination-total="22">
+;--media-img-scale:0.85;" data-marpit-pagination-total="22">
 <p><img src="images/050_default_from_SW.jpg" alt="" /></p>
 </section>
 </foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="9" data-paginate="true" data-class="media" data-theme="default" data-style="@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&amp;display=swap');
@@ -465,7 +465,7 @@ section.nature-slide {
   height: auto;
 }
 " lang="en-US" class="media" data-marpit-pagination="8" style="--paginate:true;--class:media;--theme:default;--style:@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&amp;display=swap')
-;" data-marpit-pagination-total="22">
+;--media-img-scale:0.85;" data-marpit-pagination-total="22">
 <p><img src="images/060_default_from_SE.jpg" alt="" /></p>
 </section>
 </foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="10" data-paginate="true" data-class="media" data-theme="default" data-style="@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&amp;display=swap');
@@ -513,7 +513,7 @@ section.nature-slide {
   height: auto;
 }
 " lang="en-US" class="media" data-marpit-pagination="9" style="--paginate:true;--class:media;--theme:default;--style:@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&amp;display=swap')
-;" data-marpit-pagination-total="22">
+;--media-img-scale:0.85;" data-marpit-pagination-total="22">
 <p><img src="images/070_default_from_E.jpg" alt="" /></p>
 </section>
 </foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="11" data-paginate="true" data-class="media" data-theme="default" data-style="@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&amp;display=swap');
@@ -561,7 +561,7 @@ section.nature-slide {
   height: auto;
 }
 " lang="en-US" class="media" data-marpit-pagination="10" style="--paginate:true;--class:media;--theme:default;--style:@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&amp;display=swap')
-;" data-marpit-pagination-total="22">
+;--media-img-scale:0.85;" data-marpit-pagination-total="22">
 <p><img src="images/080_default_2018_2.jpg" alt="" /></p>
 </section>
 </foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="12" data-paginate="true" data-class="media" data-theme="default" data-style="@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&amp;display=swap');
@@ -609,7 +609,7 @@ section.nature-slide {
   height: auto;
 }
 " lang="en-US" class="media" data-marpit-pagination="11" style="--paginate:true;--class:media;--theme:default;--style:@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&amp;display=swap')
-;" data-marpit-pagination-total="22">
+;--media-img-scale:0.85;" data-marpit-pagination-total="22">
 <p><img src="images/090_default_2022-4.jpg" alt="" /></p>
 </section>
 </foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="13" data-paginate="true" data-class="media" data-theme="default" data-style="@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&amp;display=swap');
@@ -657,7 +657,7 @@ section.nature-slide {
   height: auto;
 }
 " lang="en-US" class="media" data-marpit-pagination="12" style="--paginate:true;--class:media;--theme:default;--style:@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&amp;display=swap')
-;" data-marpit-pagination-total="22">
+;--media-img-scale:0.85;" data-marpit-pagination-total="22">
 <p><img src="images/100_default_2020-5.jpg" alt="" /></p>
 </section>
 </foreignObject></svg><svg data-marpit-svg="" viewBox="0 0 1280 720"><foreignObject width="1280" height="720"><section id="14" data-paginate="true" data-class="content" data-theme="default" data-style="@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&amp;display=swap');

--- a/slides.md
+++ b/slides.md
@@ -94,6 +94,8 @@ style: |
 ---
 <!-- _class: media -->
 
+<!-- _style: --media-img-scale: 0.85; -->
+
 ![width:85%](images/020_位置図1.jpg)
 
 <div class="source-note">
@@ -102,6 +104,8 @@ style: |
 
 ---
 <!-- _class: media -->
+
+<!-- _style: --media-img-scale: 0.85; -->
 
 ![width:85%](images/030_位置図2.jpg)
 
@@ -112,35 +116,49 @@ style: |
 ---
 <!-- _class: media -->
 
+<!-- _style: --media-img-scale: 0.85; -->
+
 ![width:85%](images/040_default_01.jpg)
 
 ---
 <!-- _class: media -->
+
+<!-- _style: --media-img-scale: 0.85; -->
 
 ![width:85%](images/050_default_from_SW.jpg)
 
 ---
 <!-- _class: media -->
 
+<!-- _style: --media-img-scale: 0.85; -->
+
 ![width:85%](images/060_default_from_SE.jpg)
 
 ---
 <!-- _class: media -->
+
+<!-- _style: --media-img-scale: 0.85; -->
 
 ![width:85%](images/070_default_from_E.jpg)
 
 ---
 <!-- _class: media -->
 
+<!-- _style: --media-img-scale: 0.85; -->
+
 ![width:85%](images/080_default_2018_2.jpg)
 
 ---
 <!-- _class: media -->
 
+<!-- _style: --media-img-scale: 0.85; -->
+
 ![width:85%](images/090_default_2022-4.jpg)
 
 ---
 <!-- _class: media -->
+
+<!-- _style: --media-img-scale: 0.85; -->
 
 ![width:85%](images/100_default_2020-5.jpg)
 


### PR DESCRIPTION
## Summary
- explain why media images ignored the intended Markdown scaling by inspecting generated HTML and theme CSS
- add a `--media-img-scale` CSS variable and per-slide `_style` directives so Marp slides can control image size reliably
- update the exported HTML to include the new style variable for each media slide

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ebac6207c48321863956dc2e39eaf9