### PR TITLE
Add bottom padding to slide sections for footer visibility

### DIFF
--- a/slides.md
+++ b/slides.md
@@ -13,6 +13,8 @@ style: |
     display: flex;
     flex-direction: column;
     min-height: 100%;
+    box-sizing: border-box;
+    padding-bottom: 3.5rem;
   }
   section::after {
     content: attr(data-marpit-pagination) " / " attr(data-marpit-pagination-total);


### PR DESCRIPTION
## Summary
- add box-sizing and bottom padding to slide sections in `slides.md`
- ensure slide source notes remain visible above the pagination overlay

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690be80f64c48321aae6fa57047ff1bd